### PR TITLE
Add `/tmp` access for now

### DIFF
--- a/org.kde.kate.json
+++ b/org.kde.kate.json
@@ -7,6 +7,7 @@
     "rename-icon": "kate",
     "finish-args": [
         "--device=dri",
+        "--filesystem=/tmp",
         "--filesystem=host",
         "--share=ipc",
         "--socket=cups",


### PR DESCRIPTION
This is needed as Kate creates processes on the host and shares files via `/tmp`.

This is not great but that's what we have right now. A longer term solution would be to have Kate use `xdg-run/kate` / `$XDG_RUNTIME_DIR/kate` instead.

See: https://github.com/flathub/org.kde.kate/issues/25

---

Fixes: https://github.com/flathub/org.kde.kate/issues/25