### PR TITLE
Set XDG_CURRENT_DESKTOP to kde in runtime

### DIFF
--- a/org.kde.kate.json
+++ b/org.kde.kate.json
@@ -13,7 +13,8 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--system-talk-name=org.freedesktop.UDisks2",
-        "--talk-name=org.freedesktop.Flatpak"
+        "--talk-name=org.freedesktop.Flatpak",
+        "--env=XDG_CURRENT_DESKTOP=kde"
     ],
     "modules": [
         {


### PR DESCRIPTION
Currently, QT fails to theme properly for GNOME (and potentially other desktops) inside of the Flatpak runtime. Forcefully setting XDG_CURRENT_DESKTOP to "kde" fixes this behavior. This mirrors the current manifest configuration of [org.kde.kdenlive](https://github.com/flathub/org.kde.kdenlive).

A side-effect of this change is that the cursor will change its look from the host desktop while inside of the window, but this is preferable to the app's entire aspect looking outright broken.

Kate without `XDG_CURRENT_DESKTOP` defined on Gnome 45:
![imagem](https://github.com/flathub/org.kde.kate/assets/55360900/a19bcaa7-02af-4140-a484-c738d9e63623)

Kate with `XDG_CURRENT_DESKTOP` set to `kde` on Gnome 45:
![imagem](https://github.com/flathub/org.kde.kate/assets/55360900/919c9f32-b073-4bed-b3a4-661831d470f7)

Cursor side-effect with this change:

[Gravação de ecrã a partir de 2024-01-10 18-39-38.webm](https://github.com/flathub/org.kde.kate/assets/55360900/d6f297fd-cd14-4c32-ae23-82714311a34c)

